### PR TITLE
feat: Add confirmation alert when deleting projects

### DIFF
--- a/public/Frontend/AppController.j
+++ b/public/Frontend/AppController.j
@@ -316,6 +316,28 @@ BaseURL=HostURL+"/";
     [inputController remove:sender]
 }
 
+- (void)removeProject:(id)sender
+{
+    var alert = [CPAlert alertWithMessageText:@"Delete Project"
+                                 defaultButton:@"OK"
+                               alternateButton:@"Cancel"
+                                   otherButton:nil
+                     informativeTextWithFormat:@"Are you sure you want to delete the selected project?"];
+
+    [alert beginSheetModalForWindow:[CPApp keyWindow]
+                      modalDelegate:self
+                     didEndSelector:@selector(alertDidEnd:returnCode:contextInfo:)
+                        contextInfo:nil];
+}
+
+- (void)alertDidEnd:(CPAlert)alert returnCode:(int)returnCode contextInfo:(void)contextInfo
+{
+    if (returnCode == CPAlertDefaultReturn)
+    {
+        [projectsController remove:self];
+    }
+}
+
 - (void)removeBlocks:(id)sender
 {
     [laceViewController removeBlocks:sender]

--- a/public/Frontend/Resources/gui.gsmarkup
+++ b/public/Frontend/Resources/gui.gsmarkup
@@ -38,7 +38,7 @@
                                 <tableColumn identifier="name" title="Pipeline Name" editable="YES" width="200"/>
                             </tableView>
                         </scrollView>
-                        <ButtonBar target="#CPOwner.projectsController" actionsButton="YES" minusButtonAction="remove:" plusButtonAction="insert:">
+                        <ButtonBar target="#CPOwner" actionsButton="YES" minusButtonAction="removeProject:" plusButtonAction="insert:">
                             <popUpButtonItem title="Duplicate project" target="#CPOwner" action="duplicateProject:"/>
                         </ButtonBar>
                     </vbox>


### PR DESCRIPTION
This commit adds a confirmation alert when a user tries to delete a project.

A new method `removeProject:` was added to `AppController.j` that displays a `CPAlert` to the user. The project is only deleted if the user confirms the action.

The `gui.gsmarkup` file was updated to call the new `removeProject:` method instead of directly calling `remove:` on the `projectsController`.